### PR TITLE
Implement Support for /.search Endpoints

### DIFF
--- a/src/routers.js
+++ b/src/routers.js
@@ -4,6 +4,7 @@ import {Resources} from "./routers/resources.js";
 import {Schemas} from "./routers/schemas.js";
 import {ResourceTypes} from "./routers/resourcetypes.js";
 import {ServiceProviderConfig} from "./routers/spconfig.js";
+import {Search} from "./routers/search.js";
 import {Bulk} from "./routers/bulk.js";
 import {Me} from "./routers/me.js";
 
@@ -102,6 +103,7 @@ export default class SCIMMYRouters extends Router {
         this.use(new Schemas());
         this.use(new ResourceTypes());
         this.use(new ServiceProviderConfig());
+        this.use(new Search());
         this.use(new Bulk());
         this.use(new Me(handler));
         

--- a/src/routers/resources.js
+++ b/src/routers/resources.js
@@ -1,4 +1,5 @@
 import {Router} from "express";
+import {Search} from "./search.js";
 import SCIMMY from "scimmy";
 
 /**
@@ -12,6 +13,9 @@ export class Resources extends Router {
      */
     constructor(Resource) {
         super();
+        
+        // Mount /.search endpoint for resource
+        this.use(new Search(Resource));
         
         this.get("/", async (req, res) => {
             try {

--- a/src/routers/search.js
+++ b/src/routers/search.js
@@ -1,0 +1,25 @@
+import {Router} from "express";
+import SCIMMY from "scimmy";
+
+/**
+ * SCIMMY Search Endpoint Router
+ * @since 1.0.0
+ * @class SCIMMYRouters.Search
+ */
+export class Search extends Router {
+    /**
+     * Construct an instance of an express router with endpoints for accessing Search POST endpoint
+     */
+    constructor(Resource) {
+        super();
+        
+        // Respond to POST requests for /.search endpoint
+        this.post("/.search", async (req, res) => {
+            try {
+                res.status(200).send(await (new SCIMMY.Messages.SearchRequest(req.body)).apply(!!Resource ? [Resource] : undefined));
+            } catch (ex) {
+                res.status(ex.status ?? 500).send(new SCIMMY.Messages.Error(ex));
+            }
+        });
+    }
+}


### PR DESCRIPTION
Add router for /.search endpoints using SCIMMY.Messages.SearchRequest class

Closes #2 