### PR TITLE
Add support for passing arbitrary context to incoming requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ $ npm install scimmy-routers
 In your code:
 ```js
 import express from "express";
-import SCIMMYRouters, {SCIMMY} from "scimmy-routers";
+import SCIMMY from "scimmy";
+import SCIMMYRouters from "scimmy-routers";
 
 // Create a new express app
 let app = express();
@@ -28,14 +29,19 @@ SCIMMY.Resources.declare(SCIMMY.Resources.Group, {/* Your handlers for group res
 // Instantiate SCIMMYRouters as new middleware for express
 app.use("/scim", new SCIMMYRouters({
     type: "bearer",
-    docUri: "http://example.com/help/oauth.html",
+    docUri: "https://example.com/help/oauth.html",
     // Your handler for verifying authentication status of a request
     handler: (request) => {
         if (!request.header("Authorization")?.startsWith("Bearer ")) {
             throw new Error("Authorization not detected!");
         } else {
-            // Do nothing, request is authenticated
+            return "some-user-ID";
         }
+    },
+    // Optionally, some method to provide additional context to requests...
+    context: (request) => {
+        // ...in this case, the URL params from the express request 
+        return request.params;
     }
 }));
 ```
@@ -55,5 +61,8 @@ The properties of that object are:
 *   ```handler``` - required function specifying the method to invoke to authenticate SCIM requests to this middleware.
     *   If a request is not authenticated, the function should throw a new Error with a brief message to be passed back by the response.
     *   If a specific user is authenticated, the function should return the ID string of the authenticated user.
+
+*   ```context``` - optional function specifying the method to invoke to provide additional context to SCIM requests.
+    *   Evaluated for each request, it can return anything, with the returned value passed directly to the ingress/egress/degress handler methods.
 
 *   ```docUri``` - optional string specifying the URL to use as the documentation URI for the service provider authentication scheme.

--- a/src/routers/bulk.js
+++ b/src/routers/bulk.js
@@ -9,21 +9,22 @@ import SCIMMY from "scimmy";
 export class Bulk extends Router {
     /**
      * Construct an instance of an express router with endpoints for accessing Bulk POST endpoint
+     * @param {AuthenticationContext} [context] - method to invoke to evaluate context passed to SCIMMY handlers
      */
-    constructor() {
-        super();
+    constructor(context) {
+        super({mergeParams: true});
         
         // Respond to POST requests for /Bulk endpoint
         this.post("/Bulk", async (req, res) => {
             try {
-                let {supported, maxPayloadSize, maxOperations} = SCIMMY.Config.get()?.bulk ?? {};
+                const {supported, maxPayloadSize, maxOperations} = SCIMMY.Config.get()?.bulk ?? {};
                 
                 if (!supported) {
                     res.status(501).send();
                 } else if (Number(req.header("content-length")) > maxPayloadSize) {
                     throw new SCIMMY.Types.Error(413, null, `The size of the bulk operation exceeds maxPayloadSize limit (${maxPayloadSize})`);
                 } else {
-                    res.status(200).send(await (new SCIMMY.Messages.BulkRequest(req.body, maxOperations)).apply());
+                    res.status(200).send(await (new SCIMMY.Messages.BulkRequest(req.body, maxOperations)).apply(undefined, await context(req)));
                 }
             } catch (ex) {
                 res.status(ex.status ?? 500).send(new SCIMMY.Messages.Error(ex));

--- a/src/routers/resourcetypes.js
+++ b/src/routers/resourcetypes.js
@@ -10,7 +10,7 @@ export class ResourceTypes extends Router {
      * Construct an instance of an express router with endpoints for accessing ResourceTypes
      */
     constructor() {
-        super();
+        super({mergeParams: true});
         
         this.get("/ResourceTypes", async (req, res) => {
             try {

--- a/src/routers/schemas.js
+++ b/src/routers/schemas.js
@@ -10,7 +10,7 @@ export class Schemas extends Router {
      * Construct an instance of an express router with endpoints for accessing Schemas
      */
     constructor() {
-        super();
+        super({mergeParams: true});
         
         this.get("/Schemas", async (req, res) => {
             try {

--- a/src/routers/search.js
+++ b/src/routers/search.js
@@ -9,14 +9,16 @@ import SCIMMY from "scimmy";
 export class Search extends Router {
     /**
      * Construct an instance of an express router with endpoints for accessing Search POST endpoint
+     * @param {Function|typeof SCIMMY.Types.Resource} [Resource] - the resource type instance for which endpoints are being registered
+     * @param {AuthenticationContext} [context] - method to invoke to evaluate context passed to SCIMMY handlers
      */
-    constructor(Resource) {
-        super();
+    constructor(Resource, context = (Resource.prototype instanceof SCIMMY.Types.Resource ? (() => {}) : Resource)) {
+        super({mergeParams: true});
         
         // Respond to POST requests for /.search endpoint
         this.post("/.search", async (req, res) => {
             try {
-                res.status(200).send(await (new SCIMMY.Messages.SearchRequest(req.body)).apply(!!Resource ? [Resource] : undefined));
+                res.status(200).send(await (new SCIMMY.Messages.SearchRequest(req.body)).apply(Resource.prototype instanceof SCIMMY.Types.Resource ? [Resource] : undefined, await context(req)));
             } catch (ex) {
                 res.status(ex.status ?? 500).send(new SCIMMY.Messages.Error(ex));
             }

--- a/src/routers/spconfig.js
+++ b/src/routers/spconfig.js
@@ -10,7 +10,7 @@ export class ServiceProviderConfig extends Router {
      * Construct an instance of an express router with endpoints for accessing ServiceProviderConfig
      */
     constructor() {
-        super();
+        super({mergeParams: true});
         
         this.get("/ServiceProviderConfig", async (req, res) => {
             try {


### PR DESCRIPTION
Defines a new optional `context` property on the `SCIMMYRouters` constructor `authScheme` parameter object.
The `context` property, if defined, is expected to be a method, and is called for every request that eventually reaches a resource's ingress/egress/degress handlers. The method is called with the full express request object the same way the authentication handler is currently called. This implements [option 2](https://github.com/scimmyjs/scimmy-routers/issues/16#issuecomment-1989758799) of, and resolves issue #16.