### PR TITLE
Enable absolute URLs in location properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ The properties of that object are:
 
 *   ```docUri``` - optional string specifying the URL to use as the documentation URI for the service provider authentication scheme.
 
-*   ```baseUri``` - optional string specifying the URL to use as the base URI for any location properties. This enables absolute URLs instead of relative URLs.
+*   ```baseUri``` - optional function specifying the URL to use as the base URI for any location properties. This enables absolute URLs instead of relative URLs (if function is not set or `undefined` is returned).

--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ The properties of that object are:
     *   Evaluated for each request, it can return anything, with the returned value passed directly to the ingress/egress/degress handler methods.
 
 *   ```docUri``` - optional string specifying the URL to use as the documentation URI for the service provider authentication scheme.
+
+*   ```baseUri``` - optional string specifying the URL to use as the base URI for any location properties. This enables absolute URLs instead of relative URLs.

--- a/src/routers.js
+++ b/src/routers.js
@@ -56,6 +56,14 @@ const authSchemeTypes = {
  */
 
 /**
+ * Method invoked to provide a base URI based on a SCIM request
+ * @callback BaseUriContext
+ * @param {express.Request} req - the express request to provide the base URI for
+ * @returns {String|Promise<String>|undefined|Promise<undefined>} the base URI to use for location properties in SCIM responses
+ * @private
+ */
+
+/**
  * SCIMMY HTTP Routers Class
  * @class SCIMMYRouters
  */
@@ -67,10 +75,10 @@ export default class SCIMMYRouters extends Router {
      * @param {AuthenticationHandler} authScheme.handler - method to invoke to authenticate SCIM requests
      * @param {AuthenticationContext} [authScheme.context] - method to invoke to evaluate context passed to SCIMMY handlers
      * @param {String} [authScheme.docUri] - URL to use as documentation URI for service provider authentication scheme
-     * @param {String} [authScheme.baseUri] - URL to use as the base URI to enable absolute paths in location fields
+     * @param {BaseUriContext} [authScheme.baseUri] - URL to use as the base URI to enable absolute paths in location fields
      */
     constructor(authScheme = {}) {
-        const {type, docUri, baseUri, handler, context = (() => {})} = authScheme;
+        const {type, docUri, handler, context = (() => {}), baseUri = (() => undefined)} = authScheme;
         
         super({mergeParams: true});
         
@@ -85,6 +93,8 @@ export default class SCIMMYRouters extends Router {
             throw new TypeError(`Unknown authentication scheme type '${type}' in SCIMRouters constructor`);
         if (typeof context !== "function")
             throw new TypeError("Parameter 'context' must be of type 'function' for authentication scheme in SCIMRouters constructor");
+        if (typeof baseUri !== "function")
+            throw new TypeError("Parameter 'baseUri' must be of type 'function' for authentication scheme in SCIMRouters constructor");
         
         // Register the authentication scheme, and other SCIM Service Provider Config options
         SCIMMY.Config.set({
@@ -96,9 +106,16 @@ export default class SCIMMYRouters extends Router {
         this.use(express.json({type: "application/scim+json", limit: SCIMMY.Config.get()?.bulk?.maxPayloadSize ?? "1mb"}));
         
         // Listen for incoming requests to determine basepath for all resource types
-        this.use("/", (req, res, next) => {
-            // Determine a full base path with a root if a path is given.
-            const basePath = baseUri ? baseUri.replace(/\/$/, "") + req.baseUrl : req.baseUrl;
+        this.use("/", async (req, res, next) => {
+            // Invoke base URI determination function, possible Promise
+            const baseUriValue = await baseUri(req);
+
+            // Ignore if undefined return, if undefined: just use relative URL
+            // Make sure it does not end with a / to prevent // in the URL
+            let basePath = baseUriValue ? baseUriValue.replace(/\/$/, "") : "";
+
+            // Add basepath as determined by Express
+            basePath += req.baseUrl;
 
             // Set all base paths correctly
             SCIMMY.Resources.Schema.basepath(basePath);


### PR DESCRIPTION
Although not explicitly specified in RFC 7644, the examples there include absolute URLs for location properties, such as this example:

```
   HTTP/1.1 201 Created
   Content-Type: application/scim+json
   Location:
    https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646
   ETag: W/"e180ee84f0671b1"

   {
     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
     "id":"2819c223-7f76-453a-919d-413861904646",
     "externalId":"bjensen",
     "meta":{
       "resourceType":"User",
       "created":"2011-08-01T21:32:44.882Z",
       "lastModified":"2011-08-01T21:32:44.882Z",
       "location":
   "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646",
       "version":"W\/\"e180ee84f0671b1\""
     },
     "name":{
       "formatted":"Ms. Barbara J Jensen III",
       "familyName":"Jensen",
       "givenName":"Barbara"
     },
     "userName":"bjensen"
   }
```

This PR adds the option to set this base URL, possibly from an environment variable that you set with your HTTPS SCIM root URL. This enables returning full URLs to the consumer. The field is optional and the current behaviour is maintained if you do not set the baseUri.

Additionally, my compliance test, https://github.com/suvera/scim2-compliance-test-utility, requires this as it uses these URLs to navigate the SCIM server and it does not handle relative URLs, as it's not used by the spec.