### PR TITLE
Send JSON content with 404 and 501 status codes

### DIFF
--- a/src/routers.js
+++ b/src/routers.js
@@ -169,6 +169,6 @@ export default class SCIMMYRouters extends Router {
         }
         
         // If we get to this point, there's no matching endpoints
-        this.use((req, res) => res.status(404).send());
+        this.use((req, res) => res.status(404).send(new SCIMMY.Messages.Error({status: 404, message: "Endpoint Not Found"})));
     }
 }

--- a/src/routers/bulk.js
+++ b/src/routers/bulk.js
@@ -20,7 +20,7 @@ export class Bulk extends Router {
                 const {supported, maxPayloadSize, maxOperations} = SCIMMY.Config.get()?.bulk ?? {};
                 
                 if (!supported) {
-                    res.status(501).send();
+                    res.status(501).send(new SCIMMY.Messages.Error({status: 501, message: "Endpoint Not Implemented"}));
                 } else if (Number(req.header("content-length")) > maxPayloadSize) {
                     throw new SCIMMY.Types.Error(413, null, `The size of the bulk operation exceeds maxPayloadSize limit (${maxPayloadSize})`);
                 } else {

--- a/src/routers/me.js
+++ b/src/routers/me.js
@@ -25,7 +25,7 @@ export class Me extends Router {
                 
                 // Set the actual location of the user resource, or respond with 501 not implemented
                 if (user && user?.meta?.location) res.location(user.meta.location).send(user);
-                else res.status(501).send();
+                else res.status(501).send(new SCIMMY.Messages.Error({status: 501, message: "Endpoint Not Implemented"}));
             } catch (ex) {
                 res.status(ex.status ?? 500).send(new SCIMMY.Messages.Error(ex));
             }
@@ -33,7 +33,7 @@ export class Me extends Router {
         
         // Respond with 501 not implemented to all other requests for /Me endpoint 
         this.use("/Me", (req, res) => {
-            res.status(501).send();
+            res.status(501).send(new SCIMMY.Messages.Error({status: 501, message: "Endpoint Not Implemented"}));
         });
     }
 }


### PR DESCRIPTION
Quoting https://www.rfc-editor.org/rfc/rfc7644#section-3.12

   The SCIM protocol uses the HTTP response status codes defined in
   Section 6 of [RFC7231] to indicate operation success or failure.  In
   addition to returning an HTTP response code, **implementers MUST return
   the errors in the body of the response in a JSON format**, using the
   attributes described below.


So I would say that even for 404 and 501 error responses, a JSON should be sent.