### PR TITLE
Support "application/json" content-type

### DIFF
--- a/src/routers.js
+++ b/src/routers.js
@@ -103,7 +103,7 @@ export default class SCIMMYRouters extends Router {
         });
         
         // Make sure SCIM JSON is decoded in request body
-        this.use(express.json({type: "application/scim+json", limit: SCIMMY.Config.get()?.bulk?.maxPayloadSize ?? "1mb"}));
+        this.use(express.json({type: [ "application/scim+json", "application/json" ], limit: SCIMMY.Config.get()?.bulk?.maxPayloadSize ?? "1mb"}));
         
         // Listen for incoming requests to determine basepath for all resource types
         this.use("/", async (req, res, next) => {


### PR DESCRIPTION
Quoting RFC7644, chapter 3.8, it is recommended to support this mime:

>    Service providers MUST support the "Accept" header
>    "Accept: application/scim+json" and SHOULD support the header
>    "Accept: application/json", both of which specify JSON documents
>    conforming to [RFC7159].  The format defaults to
>    "application/scim+json" if no format is specified.